### PR TITLE
Fix signin password check

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -59,8 +59,18 @@ exports.signup = async (req, res) => {
 };
 
 exports.signin = async (req, res) => {
-  const { email } = req.body;
-  const user = await User.findOne({ email });
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    throw new AppError('Please provide email and password', 400);
+  }
+
+  const user = await User.findOne({ email }).select('+password');
+
+  if (!user || !(await user.correctPassword(password, user.password))) {
+    throw new AppError('Incorrect email or password', 401);
+  }
+
   createSendToken(user, 200, res);
 };
 

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -90,11 +90,7 @@ router.post('/signup', authController.signup);
  *               message: Something went very wrong!
  */
 
-router.post(
-  '/signin',
-  passport.authenticate('local', { session: false }),
-  authController.signin
-);
+router.post('/signin', authController.signin);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- verify password before issuing JWT in `signin`
- simplify signin route to remove `passport`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548072cb7c8328addcf6b20a38cedc