### PR TITLE
Fix community moderator update logic

### DIFF
--- a/src/controllers/communityController.js
+++ b/src/controllers/communityController.js
@@ -37,7 +37,7 @@ exports.createCommunity = async (req, res, next) => {
   }
   // Remove duplicates and add the creator to the list
   const mods = moderators
-    ? [...new Set(moderators.push(user?.id))]
+    ? [...new Set([...moderators, user?.id])]
     : [user?.id];
 
   const community = await Community.create({
@@ -89,11 +89,11 @@ exports.updateCommunity = async (req, res, next) => {
 
   // Remove duplicates and add the creator to the list
   const mods = moderators
-    ? [...new Set(moderators.push(user?.id))]
+    ? [...new Set([...moderators, user?.id])]
     : [user?.id];
 
   const newCommunity = await Community.updateOne(
-    { id: req.params.id },
+    { _id: req.params.id },
     {
       name,
       moderators: mods,


### PR DESCRIPTION
## Summary
- update community moderator array merging
- correct updateOne filter to use `_id`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548246d5148328a9d953dbe5aefdde